### PR TITLE
Report errors (don't leave promise uncaught)

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,8 @@ StreamGenerators.prototype._read = function(size) {
       } else {
         this.push(null);
       }
+    }).catch((e)=> {
+      this.emit("error", e);
     });
   } catch (e) {
     this.emit("error", e);


### PR DESCRIPTION
Current version ignores exceptions thrown by generator; they end up as uncaught promise rejections and the stream is never closed.
The proposed patch reports them as error in the stream.